### PR TITLE
bump bn.js to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/crypto-browserify/createECDH",
   "dependencies": {
-    "bn.js": "^4.1.0",
+    "bn.js": "^5.0.0",
     "elliptic": "^6.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
https://github.com/indutny/elliptic/issues/191 (`createECDH` need bump to 4.1.0)