### PR TITLE
Updated Elliptic.js package from 6.5.3 to 6.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/crypto-browserify/createECDH",
   "dependencies": {
     "bn.js": "^4.1.0",
-    "elliptic": "^6.5.3"
+    "elliptic": "^6.5.4"
   },
   "devDependencies": {
     "tap-spec": "^1.0.1",


### PR DESCRIPTION
Elliptic.js 6.5.4 does a check to ensure that the public key passed in to ECDH is a point that actually exists on the curve.
This prevents a twist attack which could be used to reveal the private key of a party in an ECDH operation over a number of occurances.

https://github.com/christianlundkvist/blog/blob/master/2020_05_26_secp256k1_twist_attacks/secp256k1_twist_attacks.md
CVE: CVE-2020-28498