### PR TITLE
patch: bumps elliptic version to patch CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/crypto-browserify/createECDH",
   "dependencies": {
     "bn.js": "^4.1.0",
-    "elliptic": "^6.5.3"
+    "elliptic": "^6.5.4"
   },
   "devDependencies": {
     "tap-spec": "^1.0.1",


### PR DESCRIPTION
SEE: https://nvd.nist.gov/vuln/detail/CVE-2020-28498