### PR TITLE
Update elliptic version to `6.5.7`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/crypto-browserify/createECDH",
   "dependencies": {
     "bn.js": "^4.1.0",
-    "elliptic": "^6.5.3"
+    "elliptic": "^6.5.7"
   },
   "devDependencies": {
     "tap-spec": "^1.0.1",


### PR DESCRIPTION
- address https://www.cve.org/CVERecord?id=CVE-2024-42459
- also made related [PR](https://github.com/browserify/browserify-sign/pull/92) with same update