### PR TITLE
Update dependencies to fix known vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-ecdh",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "createECDH but browserifiable",
   "main": "index.js",
   "browser": "browser.js",
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/crypto-browserify/createECDH",
   "dependencies": {
-    "bn.js": "^4.1.0",
-    "elliptic": "^6.5.3"
+    "bn.js": "^4.12.2",
+    "elliptic": "^6.6.1"
   },
   "devDependencies": {
     "tap-spec": "^1.0.1",


### PR DESCRIPTION
Updates version

Set bn.js to 4.12.2 and elliptic to 6.6.1

To fix:
https://security.snyk.io/vuln/SNYK-JS-ELLIPTIC-8720086
https://security.snyk.io/vuln/SNYK-JS-ELLIPTIC-7577916
https://security.snyk.io/vuln/SNYK-JS-ELLIPTIC-7577917
https://security.snyk.io/vuln/SNYK-JS-ELLIPTIC-1064899
https://security.snyk.io/vuln/SNYK-JS-ELLIPTIC-571484
